### PR TITLE
Remove String/Double option/value fields from Question and QuestionsDTO

### DIFF
--- a/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/controllers/EmployeeController.java
+++ b/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/controllers/EmployeeController.java
@@ -51,6 +51,13 @@ public class EmployeeController {
     public ModelAndView showAddQuestionForm() {
         ModelAndView mav = new ModelAndView("employee-add-question");
         QuestionsDTO questionsDto = new QuestionsDTO();
+        List<Option> options = new ArrayList<>();
+
+        for(int i = 0; i < 5; i++) {
+            Option option = new Option("", 0);
+            options.add(option);
+        }
+        questionsDto.setOptions(options);
         mav.addObject("questionsDto", questionsDto);
         mav.addObject("employee", employeeService.getEmployeeById(ContextController.getEmployee().getId()));
         return mav;
@@ -78,32 +85,6 @@ public class EmployeeController {
 
         // Set questions title and available options
         questionsDto.setTitle(existingQuestion.getTitle());
-
-        if(existingQuestion.getOption1() != null) {
-            questionsDto.setOption1(existingQuestion.getOption1());
-            questionsDto.setOption1Value(existingQuestion.getOption1Value());
-        }
-
-        if(existingQuestion.getOption2() != null) {
-            questionsDto.setOption2(existingQuestion.getOption2());
-            questionsDto.setOption2Value(existingQuestion.getOption2Value());
-        }
-
-        if(existingQuestion.getOption3() != null) {
-            questionsDto.setOption3(existingQuestion.getOption3());
-            questionsDto.setOption3Value(existingQuestion.getOption3Value());
-        }
-
-        if(existingQuestion.getOption4() != null) {
-            questionsDto.setOption4(existingQuestion.getOption4());
-            questionsDto.setOption4Value(existingQuestion.getOption4Value());
-        }
-
-        if(existingQuestion.getOption5() != null) {
-            questionsDto.setOption5(existingQuestion.getOption5());
-            questionsDto.setOption5Value(existingQuestion.getOption5Value());
-        }
-
         questionsDto.setQuestionOptions(existingQuestion.getOptions());
         questionsDto.setFoodResource(existingQuestion.getFoodResource());
         questionsDto.setHousingResource(existingQuestion.getHousingResource());
@@ -126,109 +107,33 @@ public class EmployeeController {
         return "redirect:/employee/questions";
     }
 
-    /* This method is used to set properties of new and existing questions
-     * If id == -1, we are creating a new question. Otherwise, existing
-     * question id is passed  */
     public void setQuestionProps(QuestionsDTO questionsDto, long id) {
         Question question;
-        List<Option> optionsList = new ArrayList<>();
-        Option option1;
-        Option option2;
-        Option option3;
-        Option option4;
-        Option option5;
+        List<Option> options;
 
         if(id == -1) {
+            // Creating a new question
             question = new Question();
+            options = questionsDto.getOptions();
+            System.out.println("Printing option titles from setQuestionPropsExp method: \n");
+            for(Option option : options) {
+                option.setQuestion(question);
+                System.out.println("Title: " + option.getOptionTitle());
+                System.out.println("Value: " + option.getValue());
+            }
+
         } else {
+            // Editing an existing question
             question = questionService.findQuestionById(id);
-            optionsList = optionService.getOptionsByQuestionId(question.getId());
-        }
-
-        List<Option> options = new ArrayList<>();
-        String optionText = "";
-        Double optionValue = 0.0;
-
-        if(!questionsDto.getOption1().isEmpty()) {
-            optionText = questionsDto.getOption1();
-            optionValue = questionsDto.getOption1Value();
-
-            if(optionsList.size() >= 1) {
-                option1 = optionsList.get(0);
-                option1.setOptionTitle(optionText);
-                option1.setValue(optionValue);
-            } else {
-                option1 = new Option(optionText, optionValue);
+            List<Option> prevOptions = optionService.getOptionsByQuestionId(question.getId());
+            int count = 0;
+            options = questionsDto.getOptions();
+            System.out.println("Printing options from setQuestionPropsExp Method: ");
+            for(Option o : options) {
+                o.setId(prevOptions.get(count++).getId());
+                o.setQuestion(question);
+                System.out.println("Option: ID = " + o.getId() + ": title = " + o.getOptionTitle() + ", value = " + o.getValue());
             }
-            option1.setQuestion(question);
-            options.add(option1);
-            question.setOption1(optionText);
-            question.setOption1Value(optionValue);
-        }
-        if(!questionsDto.getOption2().isEmpty()) {
-            optionText = questionsDto.getOption2();
-            optionValue = questionsDto.getOption2Value();
-
-            if(optionsList.size() >= 2) {
-                option2 = optionsList.get(1);
-                option2.setOptionTitle(optionText);
-                option2.setValue(optionValue);
-            } else {
-                option2 = new Option(optionText, optionValue);
-            }
-            option2.setQuestion(question);
-            options.add(option2);
-            question.setOption2(optionText);
-            question.setOption2Value(optionValue);
-        }
-
-        if(!questionsDto.getOption3().isEmpty()) {
-            optionText = questionsDto.getOption3();
-            optionValue = questionsDto.getOption3Value();
-
-            if(optionsList.size() >= 3) {
-                option3 = optionsList.get(2);
-                option3.setOptionTitle(optionText);
-                option3.setValue(optionValue);
-            } else {
-                option3 = new Option(optionText, optionValue);
-            }
-            option3.setQuestion(question);
-            options.add(option3);
-            question.setOption3(optionText);
-            question.setOption3Value(optionValue);
-        }
-        if(!questionsDto.getOption4().isEmpty()) {
-            optionText = questionsDto.getOption4();
-            optionValue = questionsDto.getOption4Value();
-
-            if(optionsList.size() >= 4) {
-                option4 = optionsList.get(3);
-                option4.setOptionTitle(optionText);
-                option4.setValue(optionValue);
-            } else {
-                option4 = new Option(optionText, optionValue);
-            }
-            option4.setQuestion(question);
-            options.add(option4);
-            question.setOption4(optionText);
-            question.setOption4Value(optionValue);
-        }
-        if(!questionsDto.getOption5().isEmpty()) {
-            optionText = questionsDto.getOption5();
-            optionValue = questionsDto.getOption5Value();
-
-            if(optionsList.size() >= 5) {
-                option5 = optionsList.get(4);
-                option5.setOptionTitle(optionText);
-                option5.setValue(optionValue);
-            } else {
-                option5 = new Option(optionText, optionValue);
-            }
-            option5.setQuestion(question);
-            options.add(option5);
-            question.setOption5(optionText);
-            question.setOption5Value(optionValue);
         }
         question.setTitle(questionsDto.getTitle());
         question.setFoodResource(questionsDto.getFoodResource());

--- a/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/dto/AnswersDTO.java
+++ b/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/dto/AnswersDTO.java
@@ -1,6 +1,5 @@
 package com.youthhomelessnessproject.academicsuccess.dto;
 
-import com.youthhomelessnessproject.academicsuccess.models.Option;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-// TODO make sure this is implemented correctly
 public class AnswersDTO {
     Integer[] answers = new Integer[50];
 }

--- a/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/dto/QuestionsDTO.java
+++ b/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/dto/QuestionsDTO.java
@@ -8,16 +8,16 @@ public class QuestionsDTO {
 
     private String title;
     private List<Option> options;
-    private String option1;
-    private Double option1Value;
-    private String option2;
-    private Double option2Value;
-    private String option3;
-    private Double option3Value;
-    private String option4;
-    private Double option4Value;
-    private String option5;
-    private Double option5Value;
+//    private String option1;
+//    private Double option1Value;
+//    private String option2;
+//    private Double option2Value;
+//    private String option3;
+//    private Double option3Value;
+//    private String option4;
+//    private Double option4Value;
+//    private String option5;
+//    private Double option5Value;
     private Boolean foodResource;
     private Boolean housingResource;
     private Boolean dependentResource;
@@ -42,16 +42,16 @@ public class QuestionsDTO {
         this.foodResource = foodResource;
         this.housingResource = housingResource;
         this.dependentResource = dependentResource;
-        this.option1 = option1;
-        this.option1Value = option1Value;
-        this.option2 = option2;
-        this.option2Value = option2Value;
-        this.option3 = option3;
-        this.option3Value = option3Value;
-        this.option4 = option4;
-        this.option4Value = option4Value;
-        this.option5 = option5;
-        this.option5Value = option5Value;
+//        this.option1 = option1;
+//        this.option1Value = option1Value;
+//        this.option2 = option2;
+//        this.option2Value = option2Value;
+//        this.option3 = option3;
+//        this.option3Value = option3Value;
+//        this.option4 = option4;
+//        this.option4Value = option4Value;
+//        this.option5 = option5;
+//        this.option5Value = option5Value;
     }
 
     public String getTitle() { return title; }
@@ -103,83 +103,83 @@ public class QuestionsDTO {
         this.dependentResource = dependentResource;
     }
 
-    public String getOption1() {
-        return option1;
-    }
-
-    public void setOption1(String option1) {
-        this.option1 = option1;
-    }
-
-    public Double getOption1Value() {
-        return option1Value;
-    }
-
-    public void setOption1Value(Double option1Value) {
-        this.option1Value = option1Value;
-    }
-
-    public String getOption2() {
-        return option2;
-    }
-
-    public void setOption2(String option2) {
-        this.option2 = option2;
-    }
-
-    public Double getOption2Value() {
-        return option2Value;
-    }
-
-    public void setOption2Value(Double option2Value) {
-        this.option2Value = option2Value;
-    }
-
-    public String getOption3() {
-        return option3;
-    }
-
-    public void setOption3(String option3) {
-        this.option3 = option3;
-    }
-
-    public Double getOption3Value() {
-        return option3Value;
-    }
-
-    public void setOption3Value(Double option3Value) {
-        this.option3Value = option3Value;
-    }
-
-    public String getOption4() {
-        return option4;
-    }
-
-    public void setOption4(String option4) {
-        this.option4 = option4;
-    }
-
-    public Double getOption4Value() {
-        return option4Value;
-    }
-
-    public void setOption4Value(Double option4Value) {
-        this.option4Value = option4Value;
-    }
-
-    public String getOption5() {
-        return option5;
-    }
-
-    public void setOption5(String option5) {
-        this.option5 = option5;
-    }
-
-    public Double getOption5Value() {
-        return option5Value;
-    }
-
-    public void setOption5Value(Double option5Value) {
-        this.option5Value = option5Value;
-    }
+//    public String getOption1() {
+//        return option1;
+//    }
+//
+//    public void setOption1(String option1) {
+//        this.option1 = option1;
+//    }
+//
+//    public Double getOption1Value() {
+//        return option1Value;
+//    }
+//
+//    public void setOption1Value(Double option1Value) {
+//        this.option1Value = option1Value;
+//    }
+//
+//    public String getOption2() {
+//        return option2;
+//    }
+//
+//    public void setOption2(String option2) {
+//        this.option2 = option2;
+//    }
+//
+//    public Double getOption2Value() {
+//        return option2Value;
+//    }
+//
+//    public void setOption2Value(Double option2Value) {
+//        this.option2Value = option2Value;
+//    }
+//
+//    public String getOption3() {
+//        return option3;
+//    }
+//
+//    public void setOption3(String option3) {
+//        this.option3 = option3;
+//    }
+//
+//    public Double getOption3Value() {
+//        return option3Value;
+//    }
+//
+//    public void setOption3Value(Double option3Value) {
+//        this.option3Value = option3Value;
+//    }
+//
+//    public String getOption4() {
+//        return option4;
+//    }
+//
+//    public void setOption4(String option4) {
+//        this.option4 = option4;
+//    }
+//
+//    public Double getOption4Value() {
+//        return option4Value;
+//    }
+//
+//    public void setOption4Value(Double option4Value) {
+//        this.option4Value = option4Value;
+//    }
+//
+//    public String getOption5() {
+//        return option5;
+//    }
+//
+//    public void setOption5(String option5) {
+//        this.option5 = option5;
+//    }
+//
+//    public Double getOption5Value() {
+//        return option5Value;
+//    }
+//
+//    public void setOption5Value(Double option5Value) {
+//        this.option5Value = option5Value;
+//    }
 }

--- a/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/models/Question.java
+++ b/academic-success/src/main/java/com/youthhomelessnessproject/academicsuccess/models/Question.java
@@ -36,15 +36,15 @@ public class Question {
     private Boolean housingResource;
     private Boolean dependentResource;
 
-    private String option1;
-    private Double option1Value;
-    private String option2;
-    private Double option2Value;
-    private String option3;
-    private Double option3Value;
-    private String option4;
-    private Double option4Value;
-    private String option5;
-    private Double option5Value;
+//    private String option1;
+//    private Double option1Value;
+//    private String option2;
+//    private Double option2Value;
+//    private String option3;
+//    private Double option3Value;
+//    private String option4;
+//    private Double option4Value;
+//    private String option5;
+//    private Double option5Value;
 
 }

--- a/academic-success/src/main/resources/templates/employee-add-question.html
+++ b/academic-success/src/main/resources/templates/employee-add-question.html
@@ -242,54 +242,54 @@
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option1}"
+                                                                       th:field="*{options[0].optionTitle}"
                                                                        placeholder="Option 1"
                                                                        required>
                                                                 <br>
-                                                                <input type="number" step="1" min="-5.0" max="5.0"
+                                                                <input type="number" step="1" min="-5" max="5"
                                                                        class="form-control"
-                                                                       th:field="*{option1Value}"
+                                                                       th:field="*{options[0].value}"
                                                                        placeholder="Option 1 Value"
                                                                        required>
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option2}"
+                                                                       th:field="*{options[1].optionTitle}"
                                                                        placeholder="Option 2">
                                                                 <br>
-                                                                <input type="number" step="1" min="-5.0" max="5.0"
+                                                                <input type="number" step="1" min="-5" max="5"
                                                                        class="form-control"
-                                                                       th:field="*{option2Value}"
+                                                                       th:field="*{options[1].value}"
                                                                        placeholder="Option 2 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option3}"
+                                                                       th:field="*{options[2].optionTitle}"
                                                                        placeholder="Option 3">
                                                                 <br>
-                                                                <input type="number" step="1" min="-5.0" max="5.0"
+                                                                <input type="number" step="1" min="-5" max="5"
                                                                        class="form-control"
-                                                                       th:field="*{option3Value}"
+                                                                       th:field="*{options[2].value}"
                                                                        placeholder="Option 3 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option4}"
+                                                                       th:field="*{options[3].optionTitle}"
                                                                        placeholder="Option 4">
                                                                 <br>
-                                                                <input type="number" step="1" min="-5.0" max="5.0"
+                                                                <input type="number" step="1" min="-5" max="5"
                                                                        class="form-control"
-                                                                       th:field="*{option4Value}"
+                                                                       th:field="*{options[3].value}"
                                                                        placeholder="Option 4 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option5}"
+                                                                       th:field="*{options[4].optionTitle}"
                                                                        placeholder="Option 5">
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option5Value}"
+                                                                       th:field="*{options[4].value}"
                                                                        placeholder="Option 5 Value">
                                                                 <br>
 

--- a/academic-success/src/main/resources/templates/employee-edit-question.html
+++ b/academic-success/src/main/resources/templates/employee-edit-question.html
@@ -194,7 +194,7 @@
 
                 <!-- Page Heading -->
                 <div class="d-sm-flex align-items-center justify-content-between mb-4">
-                    <h1 class="h3 mb-0 text-gray-800">Add a New Question</h1>
+                    <h1 class="h3 mb-0 text-gray-800">Edit Question Details</h1>
                 </div>
 
                 <!-- Content Col -->
@@ -242,55 +242,53 @@
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option1}"
+                                                                       th:field="*{options[0].optionTitle}"
                                                                        required>
-                                                                <input type="hidden" th:field="*{options[0].optionTitle}"/>
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option1Value}"
+                                                                       th:field="*{options[0].value}"
                                                                        placeholder="Option 1 Value"
                                                                        required>
-                                                                <input type="hidden" th:field="*{options[0].value}"/>
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option2}"
+                                                                       th:field="*{options[1].optionTitle}"
                                                                        placeholder="Option 2">
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option2Value}"
+                                                                       th:field="*{options[1].value}"
                                                                        placeholder="Option 2 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option3}"
+                                                                       th:field="*{options[2].optionTitle}"
                                                                        placeholder="Option 3">
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option3Value}"
+                                                                       th:field="*{options[2].value}"
                                                                        placeholder="Option 3 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option4}"
+                                                                       th:field="*{options[3].optionTitle}"
                                                                        placeholder="Option 4">
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option4Value}"
+                                                                       th:field="*{options[3].value}"
                                                                        placeholder="Option 4 Value">
                                                                 <br>
                                                                 <input type="text"
                                                                        class="form-control"
-                                                                       th:field="*{option5}"
+                                                                       th:field="*{options[4].optionTitle}"
                                                                        placeholder="Option 5">
                                                                 <br>
                                                                 <input type="number" step="1" min="-5.0" max="5.0"
                                                                        class="form-control"
-                                                                       th:field="*{option5Value}"
+                                                                       th:field="*{options[4].value}"
                                                                        placeholder="Option 5 Value">
                                                                 <br>
 

--- a/academic-success/src/main/resources/templates/employee-questions-list.html
+++ b/academic-success/src/main/resources/templates/employee-questions-list.html
@@ -241,16 +241,16 @@
                                 <tr th:each="question : ${questions}">
 
                                     <td th:text="${question.title}"></td>
-                                    <td th:text="${question.option1}"></td>
-                                    <td th:text="${question.option1Value}"></td>
-                                    <td th:text="${question.option2}"></td>
-                                    <td th:text="${question.option2Value}"></td>
-                                    <td th:text="${question.option3}"></td>
-                                    <td th:text="${question.option3Value}"></td>
-                                    <td th:text="${question.option4}"></td>
-                                    <td th:text="${question.option4Value}"></td>
-                                    <td th:text="${question.option5}"></td>
-                                    <td th:text="${question.option5Value}"></td>
+                                    <td th:text="${question.options[0].optionTitle}"></td>
+                                    <td th:text="${question.options[0].value}"></td>
+                                    <td th:text="${question.options[1].optionTitle}"></td>
+                                    <td th:text="${question.options[1].value}"></td>
+                                    <td th:text="${question.options[2].optionTitle}"></td>
+                                    <td th:text="${question.options[2].value}"></td>
+                                    <td th:text="${question.options[3].optionTitle}"></td>
+                                    <td th:text="${question.options[3].value}"></td>
+                                    <td th:text="${question.options[4].optionTitle}"></td>
+                                    <td th:text="${question.options[4].value}"></td>
                                     <td th:text="${question.foodResource}"></td>
                                     <td th:text="${question.housingResource}"></td>
                                     <td th:text="${question.dependentResource}"></td>

--- a/academic-success/src/main/resources/templates/employee-resource-details.html
+++ b/academic-success/src/main/resources/templates/employee-resource-details.html
@@ -222,7 +222,7 @@
                                             <div th:if="${not #strings.isEmpty(resource.address.website)}">
                                                 <div class="text-s text-gray-900 mb-1">
                                                     <a th:href="@{${resource.address.website}}"
-                                                       th:text="${resource.address.website}"></a>
+                                                       th:text="${resource.address.website}" th:target="_blank"></a>
                                                 </div>
                                             </div>
                                             <div class="text-s text-gray-900 mb-3"

--- a/academic-success/src/main/resources/templates/homepage.html
+++ b/academic-success/src/main/resources/templates/homepage.html
@@ -188,11 +188,11 @@
 <script src="/js/sb-admin-2.min.js"></script>
 
 <!-- Page level plugins -->
-<script src="/vendor/chart.js/Chart.min.js"></script>
+<!--<script src="/vendor/chart.js/Chart.min.js"></script>-->
 
 <!-- Page level custom scripts -->
-<script src="/js/demo/chart-area-demo.js"></script>
-<script src="/js/demo/chart-pie-demo.js"></script>
+<!--<script src="/js/demo/chart-area-demo.js"></script>-->
+<!--<script src="/js/demo/chart-pie-demo.js"></script>-->
 
 </body>
 

--- a/academic-success/src/main/resources/templates/student-dashboard.html
+++ b/academic-success/src/main/resources/templates/student-dashboard.html
@@ -354,11 +354,11 @@
 <script src="/js/sb-admin-2.min.js"></script>
 
 <!-- Page level plugins -->
-<script src="/vendor/chart.js/Chart.min.js"></script>
+<!--<script src="/vendor/chart.js/Chart.min.js"></script>-->
 
 <!-- Page level custom scripts -->
-<script src="/js/demo/chart-area-demo.js"></script>
-<script src="/js/demo/chart-pie-demo.js"></script>
+<!--<script src="/js/demo/chart-area-demo.js"></script>-->
+<!--<script src="/js/demo/chart-pie-demo.js"></script>-->
 
 </body>
 

--- a/academic-success/src/main/resources/templates/student-resource-details.html
+++ b/academic-success/src/main/resources/templates/student-resource-details.html
@@ -217,7 +217,7 @@
                                             <div th:if="${not #strings.isEmpty(resource.address.website)}">
                                                 <div class="text-s text-gray-900 mb-1">
                                                     <a th:href="@{${resource.address.website}}"
-                                                       th:text="${resource.address.website}"></a>
+                                                       th:text="${resource.address.website}" th:target="_blank"></a>
                                                 </div>
                                             </div>
                                             <div class="text-s text-gray-900 mb-3"
@@ -311,12 +311,12 @@
 <script src="/js/sb-admin-2.min.js"></script>
 
 <!-- Page level plugins -->
-<script src="/vendor/chart.js/Chart.min.js"></script>
+<!--<script src="/vendor/chart.js/Chart.min.js"></script>-->
 
 <!-- Page level custom scripts -->
-<script src="/js/demo/chart-area-demo.js"></script>
-<script src="/js/demo/chart-pie-demo.js"></script>
-<script src="/js/demo/datatables-demo.js"></script>
+<!--<script src="/js/demo/chart-area-demo.js"></script>-->
+<!--<script src="/js/demo/chart-pie-demo.js"></script>-->
+<!--<script src="/js/demo/datatables-demo.js"></script>-->
 
 </body>
 

--- a/academic-success/src/main/resources/templates/survey.html
+++ b/academic-success/src/main/resources/templates/survey.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--<html lang="en">-->
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
@@ -24,9 +23,7 @@
 </head>
 
 <body id="page-top">
-<!--<script src="/js/timer.js" type="text/javascript"></script>-->
-<!--<script src="/js/monitor.js" type="text/javascript"></script>-->
-<!--<script src="/js/webcam.js" type="text/javascript" defer></script>-->
+
 <style>
     .sidebar #sidebarToggle {
         display: none;
@@ -59,27 +56,6 @@
 
         <!-- Divider -->
         <hr class="sidebar-divider">
-
-
-        <!-- Webcam feed-->
-<!--        <div class="sidebar-heading">-->
-<!--            <video id="webcam" style="height:150px; width:200px; border:2px solid" autoplay="true"></video>-->
-<!--        </div>-->
-
-        <!-- Time Left Heading -->
-<!--        <div class="sidebar-heading">-->
-<!--            Time Left-->
-<!--        </div>-->
-
-<!--        <div class="sidebar-heading">-->
-<!--            <p id="timerSection" style="font-size: 50px; color:white;"></p>-->
-<!--        </div>-->
-
-        <!-- Nav Item - Charts -->
-
-
-        <!-- Divider -->
-<!--        <hr class="sidebar-divider d-none d-md-block">-->
 
         <!-- Sidebar Toggler (Sidebar) -->
         <div class="text-center d-none d-md-inline">
@@ -186,18 +162,26 @@
 
                                 <label> <strong th:text="${question.title}"></strong></label>
 
-                                <ul>
-                                    <li th:each="option, i : ${question.options}" style="text-decoration:none">
-                                        <input th:name="${question.id}"
-                                               th:value="${i.index}"
-                                               th:id="${'option' + (i.index + 1)}"
-                                               type="radio"
-                                               th:answer="${i.index}"
-                                               th:field="*{answers[__${count.index}__]}"/>
-                                        <!--                                        th:field ="*{answers[__${count.index}__]}" />-->
-                                        <label th:text="${option.optionTitle}"
-                                               th:for="${'option' + (i.index + 1)}">
-                                        </label>
+<!--                                <ul style="list-style: none">-->
+                                <ul style="list-style-type: none">
+<!--                                    <li th:each="option, i : ${question.options}" style="text-decoration:none">-->
+                                    <li th:each="option, i : ${question.options}" >
+<!--                                        <div th:if="${not #strings.equals(i.optionTitle, ' ')}">-->
+<!--                                        <div th:if="${option.optionTitle} != ''">-->
+                                        <div th:if="${not #strings.isEmpty(option.optionTitle)}">
+                                            <input th:name="${question.id}"
+                                                   th:value="${i.index}"
+                                                   th:id="${'option' + (i.index + 1)}"
+                                                   type="radio"
+                                                   th:answer="${i.index}"
+                                                   th:field="*{answers[__${count.index}__]}"/>
+                                            <!--                                        th:field ="*{answers[__${count.index}__]}" />-->
+                                            <label th:text="${option.optionTitle}"
+                                                   th:for="${'option' + (i.index + 1)}">
+                                            </label>
+
+                                        </div>
+
 
                                     </li>
 
@@ -276,11 +260,11 @@
 <script src="/js/sb-admin-2.min.js"></script>
 
 <!-- Page level plugins -->
-<script src="/vendor/chart.js/Chart.min.js"></script>
+<!--<script src="/vendor/chart.js/Chart.min.js"></script>-->
 
 <!-- Page level custom scripts -->
-<script src="/js/demo/chart-area-demo.js"></script>
-<script src="/js/demo/chart-pie-demo.js"></script>
+<!--<script src="/js/demo/chart-area-demo.js"></script>-->
+<!--<script src="/js/demo/chart-pie-demo.js"></script>-->
 
 </body>
 


### PR DESCRIPTION
Fully integrate List<Option> within Question Model instead of relying on individual String/Double fields for each all over the app and database.

Refactor add/edit/list question pages and survey page to use List<Option> instead of the previously mentioned String/Double fields from Question class.